### PR TITLE
Clean up format specifiers in log_error calls

### DIFF
--- a/iouyap.c
+++ b/iouyap.c
@@ -417,7 +417,7 @@ foreign_listener (void *arg)
         }
 
       if (yap_verbose >= LOG_CRAZY)
-        debug_log_fmt ("received %d bytes (sfd=%d)\n",
+        debug_log_fmt ("received %zd bytes (sfd=%d)\n",
                        bytes_received, port->sfd);
 
 
@@ -455,7 +455,7 @@ foreign_listener (void *arg)
             {
               if (bytes_sent != -1)  /* no error, shouldn't happen */
                 {
-                  log_fmt ("sendto() only sent %d of %d bytes!"
+                  log_fmt ("sendto() only sent %zd of %zd bytes!"
                            " (sfd=%d)\n", bytes_sent,
                            bytes_received, port->sfd);
                   continue;
@@ -533,7 +533,7 @@ iou_listener (void *arg)
       port = buf[IOU_DST_PORT];
 
       if (yap_verbose >= LOG_CRAZY)
-        debug_log_fmt ("received %d bytes for port %d (sfd=%d)\n",
+        debug_log_fmt ("received %zd bytes for port %d (sfd=%d)\n",
                        bytes_received, port, sfd);
 
       /* Send on the packet, minus the IOU header */
@@ -560,7 +560,7 @@ iou_listener (void *arg)
         {
           if (bytes_sent != -1)  /* no error, shouldn't happen */
             {
-              log_fmt ("write() only sent %d of %d bytes! (sfd=%d)\n",
+              log_fmt ("write() only sent %zd of %zd bytes! (sfd=%d)\n",
                        bytes_sent, bytes_received, sfd);
               continue;
             }

--- a/netmap.c
+++ b/netmap.c
@@ -369,7 +369,7 @@ dump_port_table (void)
         continue;
 
       our_port = unpack_port (i);
-      log_fmt ("%d:%d/%d talks to %d other node(s):\n", yap_appl_id,
+      log_fmt ("%d:%d/%d talks to %zd other node(s):\n", yap_appl_id,
                our_port.bay, our_port.unit,
                (port_table[i].segment->size - 1));
 


### PR DESCRIPTION
This pull request cleans up compile warnings like:

iouyap.c: In function ‘foreign_listener’:
iouyap.c:420:9: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘ssize_t’ [-Wformat=]
         debug_log_fmt ("received %d bytes (sfd=%d)\n",
         ^

With this changeset, compiling no longer generates warnings (tested on gcc 4.8.2)
